### PR TITLE
update links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-# @uniswap/default-token-list
+# @quickswap-default-token-list
 
-[![Tests](https://github.com/Uniswap/token-lists/workflows/Tests/badge.svg)](https://github.com/Uniswap/default-token-list/actions?query=workflow%3ATests)
-[![npm](https://img.shields.io/npm/v/@uniswap/default-token-list)](https://unpkg.com/@uniswap/default-token-list@latest/)
-
-This NPM module and GitHub repo contains the default token list used in the Uniswap interface.
+This [NPM module](https://www.npmjs.com/package/quickswap-default-token-list) and GitHub repo contains the default token list used in the Quickswap interface.
 
 ## Adding a token
 
 To request that we add a token to the list, 
-[file an issue](https://github.com/Uniswap/default-token-list/issues/new?assignees=&labels=token+request&template=token-request.md&title=Add+%7BTOKEN_SYMBOL%7D%3A+%7BTOKEN_NAME%7D).
+[file an issue](https://github.com/sameepsi/quickswap-default-token-list/issues/new?assignees=&labels=token+request&template=token-request.md&title=Add+%7BTOKEN_SYMBOL%7D%3A+%7BTOKEN_NAME%7D).
 
 ### Disclaimer
 


### PR DESCRIPTION
Since this project is was forked and changed with minimal effort, the links in the README were still redirecting to uniswap (making it difficult for people to figure out how to add a token to the default list). 

This PR includes the correct link to issue reporting and removes a few invalid badges.