### PR TITLE
Add WUBQ:Wrapped Ubiq

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1160,5 +1160,13 @@
     "decimals": 18,
     "chainId": 137,
     "logoURI": "https://assets.coingecko.com/coins/images/2822/small/huobi-token-logo.png?1547036992"
+  },
+  {
+    "name": "Wrapped Ubiq",
+    "address": "0xb1c5C9b97B35592777091cD34fFff141ae866AbD",
+    "symbol": "WUBQ",
+    "decimals": 18,
+    "chainId": 137,
+    "logoURI": "https://icons.iconarchive.com/icons/cjdowner/cryptocurrency-flat/512/Ubiq-UBQ-icon.png"
   }
 ]


### PR DESCRIPTION
- [x] I understand that token listing is not required to use the QuickSwap Interface with a token.
- [x] I understand that filing an issue or adding liquidity does not guarantee addition to the QuickSwap default token list.
- [x] I will not ping the Discord/Telegram about this listing request.

Token Address(Ethereum): n/a
Token Address(Polygon): https://polygonscan.com/token/0xb1c5c9b97b35592777091cd34ffff141ae866abd
Token Name (from contract): Wrapped Ubiq
Token Decimals (from contract): 18
Token Symbol (from contract): WUBQ
Pair Address of Token on QuickSwap: https://info.quickswap.exchange/pair/0x8dccc1251f93fc4eb71dc7a686b58d3e718a5949

Link to the official homepage of token: https://ubiqsmart.com
Link to CoinMarketCap or CoinGecko page of token: https://coinmarketcap.com/currencies/ubiq/ - https://www.coingecko.com/en/coins/ubiq
