### PR TITLE
Add Grexie token

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1399,5 +1399,13 @@
     "decimals": 18,
     "chainId": 137,
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/b8086dbc7040582d1412effe7a951914d4a96eef/blockchains/ethereum/assets/0x8A9C67fee641579dEbA04928c4BC45F66e26343A/logo.png"
+  },
+  {
+    "name": "Grexie",
+    "address": "0xF9A75E8881af1BE80aE80050616185f0b924A03e",
+    "symbol": "GREX",
+    "decimals": 18,
+    "chainId": 137,
+    "logoURI": "https://i.imgur.com/yG6mNLZ.png"
   }
 ]


### PR DESCRIPTION
Token Address(Ethereum): N/A
Token Address(Polygon): 0xf9a75e8881af1be80ae80050616185f0b924a03e
Token Name (from contract): Grexie
Token Decimals (from contract): 18
Token Symbol (from contract): GREX
Pair Address of Token on QuickSwap: https://info.quickswap.exchange/pair/0x0c67122dad7e5709dbe9d12427b9179d28fc26b1

Link to the official homepage of token: https://grexie.com
Link to the white paper: https://grexie.com/whitepaper/