### PR TITLE
Fix QUICK and UNI borken logoURIs

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -45,7 +45,7 @@
     "symbol": "QUICK",
     "decimals": 18,
     "chainId": 137,
-    "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-interface/master/public/favicon.jpeg"
+    "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/quick.png"
   },
   {
     "name": "Uniswap",
@@ -53,7 +53,7 @@
     "symbol": "UNI",
     "decimals": 18,
     "chainId": 137,
-    "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-interface/master/public/favicon1.png"
+    "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-default-token-list/master/assets/maUNI.svg"
   },
   {
     "name": "OM",


### PR DESCRIPTION
Both links were broken, I now pointed them to asset files in this repo.