### PR TITLE
ADD FRTC to quickswap

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1910,5 +1910,13 @@
     "decimals": 18,
     "chainId": 137,
     "logoURI": "https://assets.coingecko.com/coins/images/26246/small/ATSRA_Token.png?1657276411"
+  },
+  {
+    "name": "Fridom Top Currencies",
+    "address": "0x2094BEBF8cD8c99a7595165C4de0054dD3191728",
+    "symbol": "FRTC",
+    "decimals": 18,
+    "chainId": 137,
+    "logoURI": "https://swiset.com/wp-content/uploads/2022/07/F02B1F1E-8F15-4245-8E60-BC33B0DF3864.png"
   }
 ]


### PR DESCRIPTION
- [x] I understand that token listing is not required to use the QuickSwap Interface with a token.
- [x] I understand that filing an issue or adding liquidity does not guarantee addition to the QuickSwap default token list.
- [x] I will not ping the Discord/Telegram about this listing request.

**Please provide the following information for your token.**

Token Address(Ethereum):
Token Address(Polygon): 0x2094bebf8cd8c99a7595165c4de0054dd3191728
Token Name (from contract): Fridom Top Currencies
Token Decimals (from contract): 18
Token Symbol (from contract): FRTC
Pair Address of Token on QuickSwap: 0x59fe73beebdb92e6c5c2cd7dad5764a6efc49044  

Link to the official homepage of token: https://fridom.finance
Link to CoinMarketCap or CoinGecko page of token: 
Issue: #125 