### PR TITLE
Add DummyToken to QuickSwap Token List

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1121,7 +1121,7 @@
     "name": "DUMMYTOKEN",
     "symbol": "DMMY",
     "decimals": 18,
-    "logoURI": "https://shlnk.in/dummytoken/icon-32.svg",
+    "logoURI": "https://shlnk.in/dummytoken/dummytoken.png",
     "trending": false
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1115,4 +1115,13 @@
     "logoURI": "https://i.imgur.com/Fr5cwbM.jpeg",
     "trending": false
   }
+  {
+    "chainId": 137,
+    "address": "0x2ed176aFEFa5DC22A09ea9D45dEe32d450cDe225",
+    "name": "DUMMYTOKEN",
+    "symbol": "DMMY",
+    "decimals": 18,
+    "logoURI": "https://shlnk.in/dummytoken/icon-32.svg",
+    "trending": false
+  }
 ]


### PR DESCRIPTION
This PR adds DummyToken (DMMY) to the Polygon token list used by QuickSwap.

    Token Name: DummyToken
    Token Symbol: DMMY
    Contract Address: 0x2ed176aFEFa5DC22A09ea9D45dEe32d450cDe225
    Decimals: 18
    Logo: https://shlnk.in/dummytoken/dummytoken.png

The token is now included with the following information:
`{
  "chainId": 137,
  "address": "0x2ed176aFEFa5DC22A09ea9D45dEe32d450cDe225",
  "name": "DummyToken",
  "symbol": "DMMY",
  "decimals": 18,
  "logoURI": "https://shlnk.in/dummytoken/dummytoken.png"
}
`
Added DummyToken (DMMY) details to mainnet.json for QuickSwap's default token list